### PR TITLE
Refactor dummy offender generator

### DIFF
--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,7 +1,7 @@
 namespace :generate do
   desc 'Generate dummy offender records (default 100k) with 1-5 identities per offender'
-  task :dummy_offenders, [:count] => :environment do |t, args|
-    count = args[:count].to_i > 0 ? args[:count].to_i : 100_000
+  task :dummy_offenders, [:count] => :environment do |_t, args|
+    count = args[:count].to_i.positive? ? args[:count].to_i : 100_000
 
     Offender.destroy_all
 

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,0 +1,18 @@
+namespace :generate do
+  desc 'Generate dummy offender records (default 100k) with 1-5 identities per offender'
+  task :dummy_offenders, [:count] => :environment do |t, args|
+    count = args[:count].to_i > 0 ? args[:count].to_i : 100_000
+
+    Offender.destroy_all
+
+    count.times do
+      offender = FactoryGirl.build(:offender)
+      next unless offender.save
+      identity = nil
+      [1, 2, 3, 4, 5].sample.times do
+        identity = FactoryGirl.create(:identity, :active, offender: offender)
+      end
+      offender.update current_identity: identity
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -15,20 +15,6 @@ namespace :import do
     FileUtils.rm_rf(directory)
   end
 
-  desc 'Create 100k offender records with identities'
-  task fake_offenders: :environment do
-    Offender.destroy_all
-    100_000.times do
-      offender = FactoryGirl.build(:offender)
-      next unless offender.save
-      identity = nil
-      [1, 2, 3, 4, 5].sample.times do
-        identity = FactoryGirl.create(:identity, :active, offender: offender)
-      end
-      offender.update current_identity: identity
-    end
-  end
-
   desc 'Import sample offender records'
   task sample: :environment do
     file = Rails.root.join('lib', 'assets', 'data', 'data.csv')


### PR DESCRIPTION
Move dummy/fake offender generator out of import.rake and into generator.rake.

Rename task to "dummy_offenders."

Takes a count argument. Defaults to generation of 100,000 dummy offenders when no argument passed.