### PR TITLE
Add check for redis connection to healthcheck

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -12,7 +12,8 @@ class HeartbeatController < ApplicationController
 
   def healthcheck
     checks = {
-      database: database_alive?
+      database: database_connected?,
+      redis: redis_connected?
     }
 
     status = :bad_gateway unless checks.values.all?
@@ -23,9 +24,13 @@ class HeartbeatController < ApplicationController
 
   private
 
-  def database_alive?
+  def database_connected?
     ActiveRecord::Base.connection.active?
   rescue PG::ConnectionBad
     false
+  end
+
+  def redis_connected?
+    !!Sidekiq.redis(&:info) rescue false
   end
 end

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -31,6 +31,8 @@ class HeartbeatController < ApplicationController
   end
 
   def redis_connected?
-    !!Sidekiq.redis(&:info) rescue false
+    Sidekiq.redis(&:info)
+  rescue Redis::CannotConnectError
+    false
   end
 end


### PR DESCRIPTION
Adds Redis to healthcheck endpoint. 
```
{"checks":{"database":true, "redis":true}}
```