### PR TITLE
Wrap create and update operations in transactions

### DIFF
--- a/app/controllers/api/v1/identities_controller.rb
+++ b/app/controllers/api/v1/identities_controller.rb
@@ -41,16 +41,22 @@ module Api
       end
 
       def create
-        offender = find_or_create_offender
-        new_identity = offender.identities.create!(identity_params)
-        offender.update!(current_identity: new_identity) unless identity_params[:offender_id]
+        new_identity = nil
+
+        ActiveRecord::Base.transaction do
+          offender = find_or_create_offender
+          new_identity = offender.identities.create!(identity_params)
+          offender.update!(current_identity: new_identity) unless identity_params[:offender_id]
+        end
 
         render json: new_identity, status: :created
       end
 
       def update
-        identity.update!(identity_params)
-        identity.offender.update!(offender_params)
+        ActiveRecord::Base.transaction do
+          identity.update!(identity_params)
+          identity.offender.update!(offender_params)
+        end
 
         render json: identity
       end

--- a/spec/controllers/api/v1/identities_controller_spec.rb
+++ b/spec/controllers/api/v1/identities_controller_spec.rb
@@ -284,7 +284,10 @@ RSpec.describe Api::V1::IdentitiesController, type: :controller do
 
           it 'does not create an identity record' do
             expect(Identity.count).to be 0
-            # expect(Offender.count).to be 0 TODO: Maybe we should avoid the creation of the offender
+          end
+
+          it 'does not create an offender record' do
+            expect(Offender.count).to be 0
           end
 
           it 'returns status 422/unprocessable entity' do
@@ -354,12 +357,16 @@ RSpec.describe Api::V1::IdentitiesController, type: :controller do
       context 'when invalid' do
         context 'with validation errors on the identity' do
           before do
-            invalid_params = params.merge('surname' => '')
+            invalid_params = params.merge('surname' => '', 'noms_id' => 'A1289BC')
             patch :update, params: { id: identity, identity: invalid_params }
           end
 
           it 'does not update the identity record' do
             expect(identity.surname).to eq('BLACK')
+          end
+
+          it 'does not update the offender record' do
+            expect(identity.offender.noms_id).to eq('A7104HJ')
           end
 
           it 'returns status "unprocessable entity"' do
@@ -376,13 +383,17 @@ RSpec.describe Api::V1::IdentitiesController, type: :controller do
 
       context 'with validation errors on the offender' do
         before do
-          invalid_params = params.merge('noms_id' => '')
+          invalid_params = params.merge('noms_id' => '', 'surname' => 'YELLOW')
           patch :update, params: { id: identity, identity: invalid_params }
           identity.reload
         end
 
         it 'does not update the identity record' do
           expect(identity.offender.noms_id).to eq('A7104HJ')
+        end
+
+        it 'does not update the identity record' do
+          expect(identity.surname).to eq('BLACK')
         end
 
         it 'returns status "unprocessable entity"' do


### PR DESCRIPTION
When we create an identity for a new offenders we need to
create the offender and update the current identity of
the offender, in case validation fails, we want to rollback
the operations.

The same goes when we update an identity and validation fails
on the offender params.