### PR TITLE
Rename 'noms_offender_id' to 'nomis_offender_id'

### DIFF
--- a/app/controllers/api/v1/identities_controller.rb
+++ b/app/controllers/api/v1/identities_controller.rb
@@ -4,10 +4,10 @@ module Api
       include Swagger::Blocks
       include IdentityResource
 
-      before_action :doorkeeper_authorize!, only: [:index, :search, :inactive, :blank_noms_offender_id, :show]
+      before_action :doorkeeper_authorize!, only: [:index, :search, :inactive, :blank_nomis_offender_id, :show]
       before_action -> { doorkeeper_authorize! :write }, only: [:create, :update, :destroy, :activate, :make_current]
 
-      after_action only: [:index, :search, :inactive, :blank_noms_offender_id] do
+      after_action only: [:index, :search, :inactive, :blank_nomis_offender_id] do
         set_pagination_headers(:identities) unless search_params[:count]
       end
 
@@ -32,8 +32,8 @@ module Api
         render json: @identities
       end
 
-      def blank_noms_offender_id
-        @identities = Identity.blank_noms_offender_id.order(:surname, :given_name_1, :given_name_2)
+      def blank_nomis_offender_id
+        @identities = Identity.blank_nomis_offender_id.order(:surname, :given_name_1, :given_name_2)
         @identities = @identities.page(params[:page]).per(params[:per_page])
 
         render json: @identities
@@ -96,7 +96,7 @@ module Api
 
       def identity_params
         params.require(:identity).permit(
-          :offender_id, :noms_offender_id, :pnc_number, :cro_number, :ethnicity_code,
+          :offender_id, :nomis_offender_id, :pnc_number, :cro_number, :ethnicity_code,
           :title, :given_name_1, :given_name_2, :given_name_3, :surname, :suffix, :date_of_birth, :gender
         )
       end

--- a/app/controllers/api/v1/schemas/identity_resource.rb
+++ b/app/controllers/api/v1/schemas/identity_resource.rb
@@ -342,9 +342,9 @@ module IdentityResource
         end
       end
 
-      swagger_path '/identities/blank_noms_offender_id' do
+      swagger_path '/identities/blank_nomis_offender_id' do
         operation :get do
-          key :description, 'Returns a paginated list of identities with blank noms_offender_id'
+          key :description, 'Returns a paginated list of identities with blank nomis_offender_id'
           key :operationId, 'blankNomsOffenderIdIdentities'
           key :produces, ['application/json']
           key :tags, ['identity']
@@ -365,7 +365,7 @@ module IdentityResource
             key :format, :int32
           end
           response 200 do
-            key :description, 'A list of identities with blank noms_offender_id'
+            key :description, 'A list of identities with blank nomis_offender_id'
             schema do
               key :type, :array
               items do

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -23,7 +23,7 @@ class Identity < ActiveRecord::Base
 
   scope :active, -> { where(status: STATUSES[:active]) }
   scope :inactive, -> { where(status: STATUSES[:inactive]) }
-  scope :blank_noms_offender_id, -> { where(noms_offender_id: [nil, '']) }
+  scope :blank_nomis_offender_id, -> { where(nomis_offender_id: [nil, '']) }
   scope :nicknames, ->(term) { where(given_name_1: Nickname.for(term.upcase).map(&:name) << term.upcase) }
   scope :soundex, ->(term) { where('SOUNDEX(surname) = SOUNDEX(?)', term.upcase) }
 

--- a/app/models/schemas/identity_model.rb
+++ b/app/models/schemas/identity_model.rb
@@ -11,7 +11,7 @@ module IdentityModel
           key :type, :string
           key :format, :uuid
         end
-        property :noms_offender_id do
+        property :nomis_offender_id do
           key :type, :string
         end
         property :noms_id do

--- a/app/serializers/identity_serializer.rb
+++ b/app/serializers/identity_serializer.rb
@@ -1,5 +1,5 @@
 class IdentitySerializer < ActiveModel::Serializer
-  attributes :id, :offender_id, :noms_offender_id, :noms_id, :nationality_code, :establishment_code,
+  attributes :id, :offender_id, :nomis_offender_id, :noms_id, :nationality_code, :establishment_code,
              :title, :given_name_1, :given_name_2, :given_name_3, :surname, :suffix, :date_of_birth, :gender,
              :pnc_number, :cro_number, :ethnicity_code, :current, :status
 end

--- a/app/services/parse_offenders.rb
+++ b/app/services/parse_offenders.rb
@@ -20,7 +20,7 @@ module ParseOffenders
       offender = Offender.find_or_create_by(noms_id: row[:noms_id])
       offender.update(offender_attrs(row))
 
-      identity = offender.identities.find_or_initialize_by(noms_offender_id: row[:noms_offender_id])
+      identity = offender.identities.find_or_initialize_by(nomis_offender_id: row[:nomis_offender_id])
       errors << row unless identity.update(identity_attrs(row))
 
       set_current_offender(offender, identity, row)
@@ -29,7 +29,7 @@ module ParseOffenders
     def keys_mapping
       {
         noms_number: :noms_id,
-        nomis_offender_id: :noms_offender_id,
+        nomis_offender_id: :nomis_offender_id,
         salutation: :title,
         gender_code: :gender,
         pnc_id: :pnc_number,
@@ -43,7 +43,7 @@ module ParseOffenders
 
     def identity_attrs(row)
       row.slice(:date_of_birth, :given_name_1, :given_name_2, :given_name_3, :surname,
-                :title, :gender, :pnc_number, :cro_number, :noms_offender_id, :ethnicity_code)
+                :title, :gender, :pnc_number, :cro_number, :nomis_offender_id, :ethnicity_code)
          .merge(status: 'active')
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
       resources :identities, format: :json, except: [:new, :edit] do
         get :search, on: :collection
         get :inactive, on: :collection
-        get :blank_noms_offender_id, on: :collection
+        get :blank_nomis_offender_id, on: :collection
         patch :make_current, on: :member
         patch :activate, on: :member
       end

--- a/db/migrate/20170616151916_rename_noms_offender_id_to_nomis_offender_id.rb
+++ b/db/migrate/20170616151916_rename_noms_offender_id_to_nomis_offender_id.rb
@@ -1,0 +1,5 @@
+class RenameNomsOffenderIdToNomisOffenderId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :identities, :noms_offender_id, :nomis_offender_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170404101013) do
+ActiveRecord::Schema.define(version: 20170616151916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20170404101013) do
 
   create_table "identities", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid   "offender_id"
-    t.string "noms_offender_id"
+    t.string "nomis_offender_id"
     t.string "title"
     t.string "given_name_1"
     t.string "given_name_2"
@@ -29,12 +29,12 @@ ActiveRecord::Schema.define(version: 20170404101013) do
     t.string "gender"
     t.string "pnc_number"
     t.string "cro_number"
-    t.string "status",           default: "inactive"
+    t.string "status",            default: "inactive"
     t.string "ethnicity_code"
     t.string "given_name_3"
     t.index ["cro_number"], name: "index_identities_on_cro_number", using: :btree
     t.index ["given_name_1"], name: "index_identities_on_given_name_1", using: :btree
-    t.index ["noms_offender_id"], name: "index_identities_on_noms_offender_id", using: :btree
+    t.index ["nomis_offender_id"], name: "index_identities_on_nomis_offender_id", using: :btree
     t.index ["offender_id"], name: "index_identities_on_offender_id", using: :btree
     t.index ["pnc_number"], name: "index_identities_on_pnc_number", using: :btree
     t.index ["surname"], name: "index_identities_on_surname", using: :btree

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -6,8 +6,8 @@ namespace :export do
     file = Rails.root.join('lib', 'assets', 'data', 'soi_extract.csv')
 
     CSV.open(file, 'wb') do |csv|
-      csv << %w(noms_offender_id identity_id offender_id)
-      Identity.find_each { |identity| csv << [identity.noms_offender_id, identity.id, identity.offender.id] }
+      csv << %w(nomis_offender_id identity_id offender_id)
+      Identity.find_each { |identity| csv << [identity.nomis_offender_id, identity.id, identity.offender.id] }
     end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -67,14 +67,14 @@ namespace :import do
 
   def identity_attrs(row)
     row.slice(:date_of_birth, :given_name_1, :given_name_2, :given_name_3, :surname,
-              :title, :gender, :pnc_number, :cro_number, :noms_offender_id)
+              :title, :gender, :pnc_number, :cro_number, :nomis_offender_id)
        .merge(id: row[:soi_identity_id], status: 'active')
   end
 
   def keys_mapping
     {
       noms_number: :noms_id,
-      nomis_offender_id: :noms_offender_id,
+      nomis_offender_id: :nomis_offender_id,
       salutation: :title,
       gender_code: :gender,
       pnc_id: :pnc_number,

--- a/spec/controllers/api/v1/identities_controller_spec.rb
+++ b/spec/controllers/api/v1/identities_controller_spec.rb
@@ -167,22 +167,22 @@ RSpec.describe Api::V1::IdentitiesController, type: :controller do
         end
       end
 
-      describe 'GET #blank_noms_offender_id' do
+      describe 'GET #blank_nomis_offender_id' do
         let!(:identity_1) do
-          create(:identity, noms_offender_id: '123456')
+          create(:identity, nomis_offender_id: '123456')
         end
 
         let!(:identity_2) do
-          create(:identity, noms_offender_id: '')
+          create(:identity, nomis_offender_id: '')
         end
 
         let!(:identity_3) do
-          create(:identity, noms_offender_id: nil)
+          create(:identity, nomis_offender_id: nil)
         end
 
-        before { get :blank_noms_offender_id }
+        before { get :blank_nomis_offender_id }
 
-        it 'returns collection of identities with blank noms_offender_id' do
+        it 'returns collection of identities with blank nomis_offender_id' do
           expect(JSON.parse(response.body).map { |p| p['id'] })
             .to match_array([identity_2['id'], identity_3['id']])
         end
@@ -571,8 +571,8 @@ RSpec.describe Api::V1::IdentitiesController, type: :controller do
       end
     end
 
-    describe 'GET #blank_noms_offender_id' do
-      before { get :blank_noms_offender_id }
+    describe 'GET #blank_nomis_offender_id' do
+      before { get :blank_nomis_offender_id }
 
       it 'returns status 401' do
         expect(response.status).to be 401

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Identity, type: :model do
 
     let!(:identity_1) do
       create(:identity, offender: offender_1, surname: 'COLE', given_name_1: 'DEBORAH',
-                        status: 'active', noms_offender_id: '')
+                        status: 'active', nomis_offender_id: '')
     end
 
     let!(:identity_2) do
-      create(:identity, offender: offender_2, surname: 'SMITH', given_name_1: 'MARK', noms_offender_id: '12345')
+      create(:identity, offender: offender_2, surname: 'SMITH', given_name_1: 'MARK', nomis_offender_id: '12345')
     end
 
     context 'active' do
@@ -42,10 +42,10 @@ RSpec.describe Identity, type: :model do
       end
     end
 
-    context 'blank_noms_offender_id' do
-      it 'scopes blank_noms_offender_id identities' do
-        expect(Identity.blank_noms_offender_id.count).to be 1
-        expect(Identity.blank_noms_offender_id.first).to eq identity_1
+    context 'blank_nomis_offender_id' do
+      it 'scopes blank_nomis_offender_id identities' do
+        expect(Identity.blank_nomis_offender_id.count).to be 1
+        expect(Identity.blank_nomis_offender_id.first).to eq identity_1
       end
     end
 

--- a/spec/services/parse_offenders_spec.rb
+++ b/spec/services/parse_offenders_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe ParseOffenders do
         end
 
         it 'imports all the fields correctly for the identity' do
-          identity = Identity.find_by!(noms_offender_id: '1055829')
+          identity = Identity.find_by!(nomis_offender_id: '1055829')
 
           expect(identity.noms_id).to eq('A1234BC')
-          expect(identity.noms_offender_id).to eq('1055829')
+          expect(identity.nomis_offender_id).to eq('1055829')
           expect(identity.given_name_1).to eq('JOHN')
           expect(identity.given_name_2).to eq('LUKE')
           expect(identity.given_name_3).to eq('FRANK')
@@ -58,9 +58,9 @@ RSpec.describe ParseOffenders do
         before do
           offender_one = create(:offender, noms_id: 'A1234BC')
           offender_two = create(:offender, noms_id: 'A1234BU')
-          create(:identity, offender: offender_one, noms_offender_id: '1056827')
-          create(:identity, offender: offender_one, noms_offender_id: '1055829')
-          create(:identity, offender: offender_two, noms_offender_id: '1055847')
+          create(:identity, offender: offender_one, nomis_offender_id: '1056827')
+          create(:identity, offender: offender_one, nomis_offender_id: '1055829')
+          create(:identity, offender: offender_two, nomis_offender_id: '1055847')
           described_class.call(csv_data)
         end
 
@@ -90,10 +90,10 @@ RSpec.describe ParseOffenders do
         end
 
         it 'updates all the fields correctly for the identity' do
-          identity = Identity.find_by!(noms_offender_id: '1055829')
+          identity = Identity.find_by!(nomis_offender_id: '1055829')
 
           expect(identity.noms_id).to eq('A1234BC')
-          expect(identity.noms_offender_id).to eq('1055829')
+          expect(identity.nomis_offender_id).to eq('1055829')
           expect(identity.given_name_1).to eq('JOHN')
           expect(identity.given_name_2).to eq('LUKE')
           expect(identity.given_name_3).to eq('FRANK')


### PR DESCRIPTION
The attribute references the primary key of the the table in the prison system NOMIS, so should correctly  be called `nomis_offender_id` and not `noms_offender_id`. 