### PR TITLE
Use HTTP_HOST to show origin of notification mail in subject line

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,11 +1,13 @@
 class NotificationMailer < ApplicationMailer
+  default to: 'single-offender-identity@digital.justice.gov.uk'
+
   def import_failed(import, error)
     @import = import
     @error = error
-    mail(to: 'single-offender-identity@digital.justice.gov.uk', subject: 'Import failed')
+    mail(subject: "Import failed (#{ENV['HTTP_HOST']})")
   end
 
   def import_not_performed
-    mail(to: 'single-offender-identity@digital.justice.gov.uk', subject: 'Import not performed in the last 24 hours')
+    mail(subject: "Import not performed in the last 24 hours (#{ENV['HTTP_HOST']})")
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe NotificationMailer, type: :mailer do
+  let!(:host) { 'somedomain.com' }
+
+  before do
+    allow(ENV).to receive(:[]).with('HTTP_HOST').and_return(host)
+  end
+
   describe '#import_failed' do
     let(:import) { instance_double('Import') }
     let(:mailer) { described_class.import_failed(import, 'Error parsing line 1234').deliver_now }
@@ -12,7 +18,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
 
     it 'renders the subject' do
-      expect(mailer.subject).to eq('Import failed')
+      expect(mailer.subject).to eq("Import failed (#{host})")
     end
 
     it 'renders the receiver email' do
@@ -28,7 +34,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:mailer) { described_class.import_not_performed.deliver_now }
 
     it 'renders the subject' do
-      expect(mailer.subject).to eq('Import not performed in the last 24 hours')
+      expect(mailer.subject).to eq("Import not performed in the last 24 hours (#{host})")
     end
 
     it 'renders the receiver email' do


### PR DESCRIPTION
Shows the host the notification mail came from in the subject line, i.e.

`Import failed (prisoners-api-dev.dsd.io)`
