### PR TITLE
Set cache headers to prevent caching by browsers

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ApplicationController < ActionController::Base
+    include CacheHeaders
+
     # Prevent CSRF attacks by raising an exception.
     # For APIs, you may want to use :null_session instead.
     protect_from_forgery with: :null_session

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include CacheHeaders
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/cache_headers.rb
+++ b/app/controllers/concerns/cache_headers.rb
@@ -1,0 +1,15 @@
+module CacheHeaders
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_cache_headers
+  end
+
+  private
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+end


### PR DESCRIPTION
Controller Concern to mix into top level ApplicationControllers to prevent caching across browsers.