### PR TITLE
Changes importer to destroy and recreate identities on each import

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'config/**/*'
     - 'spec/support/oauth_helper.rb'
     - 'vendor/**/*'
+    - 'app/services/parse_offenders.rb'
 
 # Prefer sensible naming to comments everywhere.
 Documentation:


### PR DESCRIPTION
https://github.com/ministryofjustice/offenders-api/issues/166

Interim fix for lack of NOMIS_OFFENDER_ID. Destroys and recreates identities on each import.