### PR TITLE
Whitelist application/vnd.ms-excel for CSV upload

### DIFF
--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -2,7 +2,7 @@ class FileUploader < CarrierWave::Uploader::Base
   storage :file
 
   def content_type_whitelist
-    ['text/csv', 'text/comma-separated-values']
+    ['text/csv', 'text/comma-separated-values', 'application/vnd.ms-excel']
   end
 
   def store_dir


### PR DESCRIPTION
Whitelists application/vnd.ms-excel content type as Excel save CSVs with this mime type.