### PR TITLE
Change PaperTrail::Version#item_id to uuid

### DIFF
--- a/db/migrate/20170725104015_change_versions_item_id_to_uuid.rb
+++ b/db/migrate/20170725104015_change_versions_item_id_to_uuid.rb
@@ -1,0 +1,13 @@
+class ChangeVersionsItemIdToUuid < ActiveRecord::Migration[5.0]
+  def change
+    add_column :versions, :uuid, :uuid, default: "uuid_generate_v4()", null: false
+
+    # DESTROYS ALL EXISITING VERSION RECORDS
+    PaperTrail::Version.delete_all
+
+    change_table :versions do |t|
+      t.remove :item_id
+      t.rename :uuid, :item_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170712083744) do
+ActiveRecord::Schema.define(version: 20170725104015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,13 +128,12 @@ ActiveRecord::Schema.define(version: 20170712083744) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",  null: false
-    t.integer  "item_id",    null: false
-    t.string   "event",      null: false
+    t.string   "item_type",                                        null: false
+    t.string   "event",                                            null: false
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
+    t.uuid     "item_id",    default: -> { "uuid_generate_v4()" }, null: false
   end
 
 end


### PR DESCRIPTION
The `versions` table PaperTrail creates sets up a polymorphic relationship with the models it is versioning. This is achieved with `item_type` and `item_id` columns. The `item_id` column is an integer - which is a problem since we're using UUIDs for our primary key ids on the Identity and Offender models. This migration changes the type of `item_id` to uuid but has to destroy all previous version records.